### PR TITLE
把“oython”改为“python”

### DIFF
--- a/md/201030-192577-020103 lxml 元素_树形结构.sy.md
+++ b/md/201030-192577-020103 lxml 元素_树形结构.sy.md
@@ -76,7 +76,7 @@ enable_checker: true
 - 这是一个开源的项目lxml
 	- l的意思是library
 	- xml的意思就是e`x`tensible `m`arkup `l`anguage
-	- 整体的意思就是一个能够简单地处理xml的oython库
+	- 整体的意思就是一个能够简单地处理xml的python库
 
 
 ### 打开站点


### PR DESCRIPTION
如下图所示，是在蓝桥云课发现拼写错误的

https://onezhai-1253282588.cos.ap-shanghai.myqcloud.com/oython.png